### PR TITLE
Add prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "test": "npm run build && jest",
     "build": "tsc",
-    "clean": "rimraf lib"
+    "clean": "rimraf lib",
+    "prepare": "npm run clean && npm run build"
   },
   "keywords": [
     "multer",


### PR DESCRIPTION
## What is the issue?
Currently, when running `npm i`/`npm install` to install this library, we don't get the latest updates. For example, in `node_modules/multer-cloud-storage/src/index.ts` it is possible to see:
```typescript
_removeFile =  (req, file, cb) => {
	const blobFile = this.getBlobFileReference( req, file );
	if(blobFile !== false) {
		var blobName = blobFile.destination + blobFile.filename;
		var blob = this.gcsBucket.file(blobName);
		blob.delete();
		cb();
	}
};
```

But in `node_modules/multer-cloud-storage/lib/index.js`, the same function is still missing the `cb()`:
```javascript
this._removeFile = function (req, file, cb) {
    var blobFile = _this.getBlobFileReference(req, file);
    if (blobFile !== false) {
        var blobName = blobFile.destination + blobFile.filename;
        var blob = _this.gcsBucket.file(blobName);
        blob.delete();
    }
};
```

## What does this PR do?
It adds npm's `prepare` script, which will delete the `lib` folder and compile it again every time `npm i`/`npm install` is run.

Here is the description of what `prepare` does from npm:
```
Run both BEFORE the package is packed and published, and on local npm install without any arguments. This is run AFTER prepublish, but BEFORE prepublishOnly. NOTE: If a package being installed through git contains a prepare script, its dependencies and devDependencies will be installed, and the prepare script will be run, before the package is packaged and installed.
```

[Reference](https://docs.npmjs.com/cli/v8/using-npm/scripts#life-cycle-scripts)